### PR TITLE
[FEAT] Google SMTP 를 이용한 회원가입 Two-Factor 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -38,6 +41,12 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // env
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/twofactorauthentication/TwoFactorAuthenticationApplication.java
+++ b/src/main/java/org/example/twofactorauthentication/TwoFactorAuthenticationApplication.java
@@ -2,7 +2,9 @@ package org.example.twofactorauthentication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class TwoFactorAuthenticationApplication {
 

--- a/src/main/java/org/example/twofactorauthentication/common/encrypto/EncryptionUtil.java
+++ b/src/main/java/org/example/twofactorauthentication/common/encrypto/EncryptionUtil.java
@@ -1,0 +1,51 @@
+package org.example.twofactorauthentication.common.encrypto;
+
+import org.example.twofactorauthentication.common.error.BusinessException;
+import org.example.twofactorauthentication.common.error.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class EncryptionUtil {
+    @Value("${encryption.key}")
+    private String secretKey;
+
+    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+
+    public String encrypt(String value) {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(secretKey.substring(0, 16).getBytes());
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] encrypted = cipher.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.ENCRYPTION_FAILED, e);
+        }
+    }
+
+    public String decrypt(String encryptedValue) {
+        try {
+            SecretKeySpec keySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "AES");
+            IvParameterSpec ivParameterSpec = new IvParameterSpec(secretKey.substring(0, 16).getBytes());
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivParameterSpec);
+
+            byte[] decrypted = cipher.doFinal(Base64.getUrlDecoder().decode(encryptedValue));
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.DECRYPTION_FAILED, e);
+        }
+    }
+}
+

--- a/src/main/java/org/example/twofactorauthentication/common/error/BusinessException.java
+++ b/src/main/java/org/example/twofactorauthentication/common/error/BusinessException.java
@@ -11,4 +11,9 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/org/example/twofactorauthentication/common/error/ErrorCode.java
+++ b/src/main/java/org/example/twofactorauthentication/common/error/ErrorCode.java
@@ -21,11 +21,18 @@ public enum ErrorCode {
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 에러가 발생하였습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED.value(), "Refresh 토큰을 찾을 수 없습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN.value(), "Refresh 토큰이 만료되었습니다."),
+    UNVERIFIED_EMAIL(HttpStatus.FORBIDDEN.value(), "이메일 인증이 필요합니다."),
 
     // User Domain Exception
     EXISTS_ALREADY_USER(HttpStatus.BAD_REQUEST.value(), "해당 닉네임을 가진 유저가 이미 존재합니다."),
-    ;
+    EXISTS_ALREADY_EMAIL(HttpStatus.BAD_REQUEST.value(), "해당 이메일이 존재합니다."),
+    INVALID_EMAIL_CODE(HttpStatus.UNAUTHORIZED.value(), "이메일 인증코드가 일치하지 않습니다."),
 
+    // Encrypto Exception
+    ENCRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "암호화를 실패하였습닌다."),
+    DECRYPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR.value(), "복호화를 실패하였습니다."),
+
+    ;
     private final int status;
     private final String message;
 

--- a/src/main/java/org/example/twofactorauthentication/config/redis/RedisConfig.java
+++ b/src/main/java/org/example/twofactorauthentication/config/redis/RedisConfig.java
@@ -1,0 +1,27 @@
+package org.example.twofactorauthentication.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        StringRedisSerializer stringSerializer = new StringRedisSerializer();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(stringSerializer);
+        template.setValueSerializer(stringSerializer);
+        return template;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+}

--- a/src/main/java/org/example/twofactorauthentication/controller/AuthController.java
+++ b/src/main/java/org/example/twofactorauthentication/controller/AuthController.java
@@ -1,0 +1,23 @@
+package org.example.twofactorauthentication.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.twofactorauthentication.common.format.ApiResult;
+import org.example.twofactorauthentication.service.AuthService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/auth/verify")
+    public ResponseEntity<ApiResult<Void>> verifyEmail(@RequestParam String email, @RequestParam String code) {
+        authService.verificationEmail(email, code);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResult.success(null));
+    }
+}

--- a/src/main/java/org/example/twofactorauthentication/controller/dto/rep/UserCreateRepDto.java
+++ b/src/main/java/org/example/twofactorauthentication/controller/dto/rep/UserCreateRepDto.java
@@ -26,11 +26,15 @@ public class UserCreateRepDto {
     @Schema(description = "닉네임", example = "Spring")
     private String nickname;
 
+    @Schema(description = "이메일", example = "test@example.com")
+    private String email;
+
     public static User from(UserCreateRepDto dto, String encodedPassword) {
         return User.builder()
                 .nickname(dto.getNickname())
                 .username(dto.getUsername())
                 .password(encodedPassword)
+                .email(dto.getEmail())
                 .authorities(List.of(Role.USER))
                 .build();
     }

--- a/src/main/java/org/example/twofactorauthentication/domain/user/Role.java
+++ b/src/main/java/org/example/twofactorauthentication/domain/user/Role.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum Role {
     USER("ROLE_USER"),
-    ADMIN("ROLE_ADMIN");
+    ADMIN("ROLE_ADMIN"),
+    VERIFY_USER("ROLE_VERIFY_USER");
 
     private final String authorityName;
 

--- a/src/main/java/org/example/twofactorauthentication/domain/user/User.java
+++ b/src/main/java/org/example/twofactorauthentication/domain/user/User.java
@@ -25,6 +25,8 @@ public class User {
     private String password;
     @Column(unique = true, nullable = false)
     private String nickname;
+    @Column(unique = true, nullable = false)
+    private String email;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(
@@ -35,11 +37,16 @@ public class User {
     private List<Role> authorities = new ArrayList<>();
 
     @Builder
-    public User(Long id, String username, String password, String nickname, List<Role> authorities) {
+    public User(Long id, String username, String password, String nickname, String email, List<Role> authorities) {
         this.id = id;
         this.username = username;
         this.password = password;
         this.nickname = nickname;
         this.authorities = authorities;
+        this.email = email;
+    }
+
+    public void addAuthorizationRole() {
+        this.authorities.add(Role.VERIFY_USER);
     }
 }

--- a/src/main/java/org/example/twofactorauthentication/domain/user/UserRepository.java
+++ b/src/main/java/org/example/twofactorauthentication/domain/user/UserRepository.java
@@ -5,5 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
+
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/example/twofactorauthentication/event/UserRegisterEvent.java
+++ b/src/main/java/org/example/twofactorauthentication/event/UserRegisterEvent.java
@@ -1,0 +1,4 @@
+package org.example.twofactorauthentication.event;
+
+public record UserRegisterEvent(String email) {
+}

--- a/src/main/java/org/example/twofactorauthentication/event/UserRegisterEventListener.java
+++ b/src/main/java/org/example/twofactorauthentication/event/UserRegisterEventListener.java
@@ -1,0 +1,39 @@
+package org.example.twofactorauthentication.event;
+
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.twofactorauthentication.service.MailService;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserRegisterEventListener {
+
+    private final MailService mailService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final long VERIFICATION_CODE_EXPIRATION = 10 * 60;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUserRegistration(UserRegisterEvent event) {
+        try {
+            String code = mailService.sendMail(event.email());
+            ValueOperations<String, String> ops = redisTemplate.opsForValue();
+            ops.set(event.email(), code, Duration.ofSeconds(VERIFICATION_CODE_EXPIRATION));
+        } catch (MessagingException e) {
+            log.warn("Mail 전송 실패 : {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/example/twofactorauthentication/service/AuthService.java
+++ b/src/main/java/org/example/twofactorauthentication/service/AuthService.java
@@ -1,0 +1,39 @@
+package org.example.twofactorauthentication.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.twofactorauthentication.common.encrypto.EncryptionUtil;
+import org.example.twofactorauthentication.common.error.BusinessException;
+import org.example.twofactorauthentication.common.error.ErrorCode;
+import org.example.twofactorauthentication.domain.user.User;
+import org.example.twofactorauthentication.domain.user.UserRepository;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+    private final EncryptionUtil encryptionUtil;
+
+    @Transactional
+    public void verificationEmail(String email, String code) {
+        ValueOperations<String, String> ops = redisTemplate.opsForValue();
+        String decryptedEmail = encryptionUtil.decrypt(email);
+        String storedCode = ops.get(decryptedEmail);
+        if (!storedCode.equals(code)) {
+            throw new BusinessException(ErrorCode.INVALID_EMAIL_CODE);
+        }
+        redisTemplate.delete(decryptedEmail);
+
+        User findUser = userRepository.findByEmail(decryptedEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        findUser.addAuthorizationRole();
+        userRepository.save(findUser);
+    }
+}

--- a/src/main/java/org/example/twofactorauthentication/service/MailService.java
+++ b/src/main/java/org/example/twofactorauthentication/service/MailService.java
@@ -1,0 +1,60 @@
+package org.example.twofactorauthentication.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.twofactorauthentication.common.encrypto.EncryptionUtil;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final EncryptionUtil encryptionUtil;
+    private static final String MAIL_SUBJECT = "인증 코드 안내";
+
+    @Value("${spring.mail.username}")
+    String host;
+
+    public String sendMail(String to) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true, StandardCharsets.UTF_8.name());
+
+        Context context = new Context();
+        String code = generateVerificationCode();
+        context.setVariable("code", code);
+        context.setVariable("email", encryptionUtil.encrypt(to));
+
+        String htmlContent = templateEngine.process("email/verification", context);
+
+        mimeMessageHelper.setFrom(host);
+        mimeMessageHelper.setTo(to);
+        mimeMessageHelper.setSubject(MAIL_SUBJECT);
+        mimeMessageHelper.setText(htmlContent, true);
+
+        javaMailSender.send(message);
+
+        return code;
+    }
+
+    private String generateVerificationCode() {
+        Random random = new Random();
+        StringBuilder code = new StringBuilder();
+        IntStream.range(0, 6).forEach(e -> code.append(random.nextInt(10)));
+        return code.toString();
+    }
+
+}

--- a/src/main/java/org/example/twofactorauthentication/service/UserService.java
+++ b/src/main/java/org/example/twofactorauthentication/service/UserService.java
@@ -1,6 +1,7 @@
 package org.example.twofactorauthentication.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.twofactorauthentication.common.error.BusinessException;
 import org.example.twofactorauthentication.common.error.ErrorCode;
 import org.example.twofactorauthentication.controller.dto.rep.UserCreateRepDto;
@@ -8,27 +9,39 @@ import org.example.twofactorauthentication.controller.dto.resp.UserCreateRespDto
 import org.example.twofactorauthentication.controller.dto.resp.UserInfoRespDto;
 import org.example.twofactorauthentication.domain.user.User;
 import org.example.twofactorauthentication.domain.user.UserRepository;
+import org.example.twofactorauthentication.event.UserRegisterEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public UserCreateRespDto register(UserCreateRepDto dto) {
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
 
-        userRepository.findByNickname(dto.getNickname())
-                .ifPresent(user -> {
-                    throw new BusinessException(ErrorCode.EXISTS_ALREADY_USER);
-                });
+        boolean isExistsNickname = userRepository.existsByNickname(dto.getNickname());
+        if (isExistsNickname) {
+            throw new BusinessException(ErrorCode.EXISTS_ALREADY_USER);
+        }
+
+        boolean isExistsEmail = userRepository.existsByEmail(dto.getEmail());
+        if (isExistsEmail) {
+            throw new BusinessException(ErrorCode.EXISTS_ALREADY_EMAIL);
+        }
 
         User user = UserCreateRepDto.from(dto, encodedPassword);
         User savedUser = userRepository.save(user);
+
+        applicationEventPublisher.publishEvent(new UserRegisterEvent(dto.getEmail()));
+
         return new UserCreateRespDto(savedUser);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,29 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${EMAIL_USERNAME}
+    password: ${EMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    default-encoding: UTF-8
+  thymeleaf:
+    prefix: classpath:/templates/
+    suffix: .html
+    mode: HTML
+    encoding: UTF-8
+    cache: false
+
 
 jwt:
   secret:
-    key: YyZ1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z7A8B9C0D1
+    key: ${JWT_KEY}
 
 logging:
   level:
@@ -34,3 +53,6 @@ logging:
     org.springframework.security.web.FilterChainProxy: TRACE
     org.springframework.security.web.access: TRACE
     org.springframework.security.web.context: TRACE
+
+encryption:
+  key: ${ENCRYPTION_KEY}

--- a/src/main/resources/templates/email/verification.html
+++ b/src/main/resources/templates/email/verification.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+<div style="padding: 20px; background-color: #f5f5f5; font-family: Arial, sans-serif;">
+    <div style="background-color: white; padding: 20px; border-radius: 5px; margin: 0 auto; max-width: 600px;">
+        <h2>이메일 인증</h2>
+        <p>안녕하세요. 아래의 인증 코드를 입력해주세요.</p>
+        <div style="background-color: #f8f9fa; padding: 10px; text-align: center; font-size: 24px; font-weight: bold; margin: 20px 0; border-radius: 5px; border: 1px solid #dee2e6;"
+             th:text="${code}">
+        </div>
+        <a th:href="@{'http://localhost:9090/auth/verify?email=' + ${email} + '&code=' + ${code}}" style="display: block; text-align: center; background-color: #007bff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; margin: 20px 0;">
+            인증하기
+        </a>
+        <p>이 인증 코드는 10분간 유효합니다.</p>
+        <p>본인이 요청하지 않은 경우 이 이메일을 무시하셔도 됩니다.</p>
+        <div style="margin-top: 20px; text-align: center; color: #6c757d; font-size: 14px;">
+            <p>본 메일은 발신 전용입니다.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
회원가입시 구글 smtp 을 이용하여 이메일 인증을 수행합니다. 
이메일 인증을 수행하지 않은 사용자는 애플리케이션을 이용할 수 없습니다. 
회원가입 시 비동기로 이벤트를 발행하여 인증 이메일을 발송합니다. 
이메일 발송은 비동기로 동작하며 회원가입이 로직이 커밋된 이후 수행됩니다. 
해당 로직은 재시도 로직을 구현하지 않았습니다. (고려해야할 부분인 서킷 브레이커까지 러닝커브발생) 